### PR TITLE
Add marketplace.json for plugin discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "git-governor",
+  "description": "Git governance plugin for Claude Code",
+  "owner": {
+    "name": "allixsenos",
+    "url": "https://github.com/allixsenos"
+  },
+  "plugins": [
+    {
+      "name": "git-governor",
+      "source": "./",
+      "description": "Enforce git governance — block amends, direct commits to protected branches, force pushes, and destructive resets",
+      "version": "1.0.0"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the marketplace manifest so the repo can be registered as a Claude Code plugin marketplace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)