### PR TITLE
Rename marketplace to agent-plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
-  "name": "claude-plugins",
-  "description": "Claude Code plugins by allixsenos",
+  "name": "agent-plugins",
+  "description": "Agent plugins by allixsenos",
   "owner": {
     "name": "allixsenos",
     "url": "https://github.com/allixsenos"


### PR DESCRIPTION
\"claude-plugins\" is reserved by Anthropic. Rename to \"agent-plugins\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)