### PR TITLE
feat: tri-state rule config — deny, ask, or false

### DIFF
--- a/plugins/git-governor/README.md
+++ b/plugins/git-governor/README.md
@@ -2,18 +2,18 @@
 
 A Claude Code plugin that enforces git governance via PreToolUse hooks. Install once, never worry about Claude nuking your git history again.
 
-## What it blocks
+## Rules
 
 | Rule | Default | Description |
 |------|---------|-------------|
-| `no-amend` | on | Block `git commit --amend` |
-| `no-commit-on-protected` | on | Block `git commit` on protected branches |
-| `no-push-to-protected` | on | Block `git push` targeting protected branches |
-| `no-force-push` | on | Block `--force`, `--force-with-lease`, `+refs` push syntax |
-| `no-reset-hard` | on | Block `git reset --hard` |
-| `no-discard-all` | on | Block `git checkout .`, `git restore .`, `git clean -f` |
-| `no-rebase-on-protected` | on | Block `git rebase` while on a protected branch |
-| `no-add-all` | on | Block `git add .` and `git add -A` (require explicit file paths) |
+| `no-amend` | deny | Block `git commit --amend` |
+| `no-commit-on-protected` | deny | Block `git commit` on protected branches |
+| `no-push-to-protected` | deny | Block `git push` targeting protected branches |
+| `no-force-push` | deny | Block `--force`, `--force-with-lease`, `+refs` push syntax |
+| `no-reset-hard` | deny | Block `git reset --hard` |
+| `no-discard-all` | deny | Block `git checkout .`, `git restore .`, `git clean -f` |
+| `no-rebase-on-protected` | deny | Block `git rebase` while on a protected branch |
+| `no-add-all` | deny | Block `git add .` and `git add -A` (require explicit file paths) |
 | `require-git-repo` | **off** | Block `Write`/`Edit` to files outside a git repo (opt-in) |
 
 Protected branches default to `main` and `master`.
@@ -35,20 +35,32 @@ Drop a `.claude/git-governor.json` in your project root to override defaults:
 {
   "protected-branches": ["main", "master", "release/*"],
   "rules": {
-    "no-amend": true,
-    "no-force-push": true,
-    "no-commit-on-protected": true,
-    "no-push-to-protected": true,
-    "no-reset-hard": true,
-    "no-discard-all": true,
+    "no-amend": "deny",
+    "no-force-push": "deny",
+    "no-commit-on-protected": "ask",
+    "no-push-to-protected": "deny",
+    "no-reset-hard": "deny",
+    "no-discard-all": "ask",
     "no-rebase-on-protected": false,
-    "no-add-all": true,
-    "require-git-repo": true
+    "no-add-all": "ask",
+    "require-git-repo": "deny"
   }
 }
 ```
 
 Glob patterns work for branch names (`release/*` matches `release/1.0`).
+
+### Rule modes
+
+Every rule supports three modes:
+
+| Mode | Effect |
+|------|--------|
+| `"deny"` / `true` | Hard block — tool call is prevented |
+| `"ask"` | Prompt the user for confirmation before proceeding |
+| `false` | Disabled — no check performed |
+
+Use `"deny"` for operations that should never happen (force push, reset --hard). Use `"ask"` for operations where you want a human checkpoint (committing on protected, discarding changes). Backward compatible: `true` still works as an alias for `"deny"`.
 
 ## License
 

--- a/plugins/git-governor/hooks/git-governor.sh
+++ b/plugins/git-governor/hooks/git-governor.sh
@@ -12,14 +12,14 @@ CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 
 DEFAULT_PROTECTED_BRANCHES='["main","master"]'
 DEFAULT_RULES='{
-  "no-amend": true,
-  "no-commit-on-protected": true,
-  "no-push-to-protected": true,
-  "no-force-push": true,
-  "no-reset-hard": true,
-  "no-discard-all": true,
-  "no-rebase-on-protected": true,
-  "no-add-all": true,
+  "no-amend": "deny",
+  "no-commit-on-protected": "deny",
+  "no-push-to-protected": "deny",
+  "no-force-push": "deny",
+  "no-reset-hard": "deny",
+  "no-discard-all": "deny",
+  "no-rebase-on-protected": "deny",
+  "no-add-all": "deny",
   "require-git-repo": false
 }'
 
@@ -27,18 +27,19 @@ DEFAULT_RULES='{
 CONFIG_FILE="${CWD:-.}/.claude/git-governor.json"
 if [[ -f "$CONFIG_FILE" ]]; then
   PROTECTED_BRANCHES=$(jq -c '.["protected-branches"] // '"$DEFAULT_PROTECTED_BRANCHES" "$CONFIG_FILE")
-  rule_enabled() {
+  rule_mode() {
     local val
-    val=$(jq -r ".rules[\"$1\"] // null" "$CONFIG_FILE")
-    if [[ "$val" == "null" ]]; then
-      echo "$DEFAULT_RULES" | jq -r ".[\"$1\"]"
+    # Use has() to distinguish "key absent" from "key set to false"
+    if jq -e ".rules | has(\"$1\")" "$CONFIG_FILE" > /dev/null 2>&1; then
+      val=$(jq -r ".rules[\"$1\"]" "$CONFIG_FILE")
     else
-      echo "$val"
+      val=$(echo "$DEFAULT_RULES" | jq -r ".[\"$1\"]")
     fi
+    echo "$val"
   }
 else
   PROTECTED_BRANCHES="$DEFAULT_PROTECTED_BRANCHES"
-  rule_enabled() {
+  rule_mode() {
     echo "$DEFAULT_RULES" | jq -r ".[\"$1\"]"
   }
 fi
@@ -68,14 +69,28 @@ ask() {
   exit 0
 }
 
-# Backward-compatible alias
-block() { deny "$@"; }
+# Enforce a rule based on its mode: "deny" / true → deny, "ask" → ask, false → skip
+enforce() {
+  local mode="$1" reason="$2"
+  case "$mode" in
+    deny|true) deny "$reason" ;;
+    ask)       ask "$reason" ;;
+    *)         return ;;
+  esac
+}
+
+# Check if a rule is active (anything other than false/null)
+rule_active() {
+  local mode="$1"
+  [[ "$mode" != "false" ]] && [[ "$mode" != "null" ]] && [[ -n "$mode" ]]
+}
 
 # --- Write|Edit rules ---
 
 if [[ "$TOOL_NAME" == "Write" || "$TOOL_NAME" == "Edit" ]]; then
-  # 8. Require git repo for file edits (opt-in)
-  if [[ "$(rule_enabled require-git-repo)" == "true" ]] && [[ -n "$FILE_PATH" ]]; then
+  # Require git repo for file edits (opt-in)
+  MODE=$(rule_mode require-git-repo)
+  if rule_active "$MODE" && [[ -n "$FILE_PATH" ]]; then
     FILE_DIR=$(dirname "$FILE_PATH")
     if ! git -C "$FILE_DIR" rev-parse --git-dir > /dev/null 2>&1; then
       # Check for opt-out in CLAUDE.md (search upward)
@@ -91,7 +106,7 @@ if [[ "$TOOL_NAME" == "Write" || "$TOOL_NAME" == "Edit" ]]; then
         CHECK_DIR=$(dirname "$CHECK_DIR")
       done
       if [[ "$OPTED_OUT" == "false" ]]; then
-        block "No git repository found for ${FILE_PATH}. Initialize a git repo, or add a git opt-out note to CLAUDE.md."
+        enforce "$MODE" "No git repository found for ${FILE_PATH}. Initialize a git repo, or add a git opt-out note to CLAUDE.md."
       fi
     fi
   fi
@@ -119,95 +134,102 @@ if ! printf '%s' "$SCAN" | grep -qE '\bgit\b'; then
 fi
 
 # 1. No amend
-if [[ "$(rule_enabled no-amend)" == "true" ]]; then
+MODE=$(rule_mode no-amend)
+if rule_active "$MODE"; then
   if printf '%s' "$SCAN" | grep -qE '\bgit\s+commit\b.*--amend\b'; then
-    block "git commit --amend is blocked. Create a new commit instead."
+    enforce "$MODE" "git commit --amend is blocked. Create a new commit instead."
   fi
 fi
 
 # 2. No force push (check before push-to-protected since it's more specific)
-if [[ "$(rule_enabled no-force-push)" == "true" ]]; then
+MODE=$(rule_mode no-force-push)
+if rule_active "$MODE"; then
   if printf '%s' "$SCAN" | grep -qE '\bgit\s+push\b.*(\s-f\b|\s--force\b|\s--force-with-lease\b)'; then
-    block "Force push is blocked. Push normally or create a new branch."
+    enforce "$MODE" "Force push is blocked. Push normally or create a new branch."
   fi
   # +refspec syntax: git push origin +branch
   if printf '%s' "$SCAN" | grep -qE '\bgit\s+push\b.*\s\+\w'; then
-    block "Force push via +refspec is blocked. Push normally or create a new branch."
+    enforce "$MODE" "Force push via +refspec is blocked. Push normally or create a new branch."
   fi
 fi
 
 # 3. No push to protected branch
-if [[ "$(rule_enabled no-push-to-protected)" == "true" ]]; then
+MODE=$(rule_mode no-push-to-protected)
+if rule_active "$MODE"; then
   if printf '%s' "$SCAN" | grep -qE '\bgit\s+push\b'; then
     # Check for explicit branch name in command
     for branch in $(echo "$PROTECTED_BRANCHES" | jq -r '.[]'); do
-      # Match: git push origin main, git push origin main:main, etc.
       if printf '%s' "$SCAN" | grep -qE "\bgit\s+push\b.*\b${branch}\b"; then
-        block "Pushing to protected branch '${branch}' is blocked."
+        enforce "$MODE" "Pushing to protected branch '${branch}' is blocked."
       fi
     done
     # Bare "git push" while on a protected branch
     if printf '%s' "$SCAN" | grep -qE '\bgit\s+push\s*$' || printf '%s' "$SCAN" | grep -qE '\bgit\s+push\s+(origin|upstream)\s*$'; then
       BRANCH=$(current_branch)
       if [[ -n "$BRANCH" ]] && is_protected "$BRANCH"; then
-        block "Pushing to protected branch '${BRANCH}' is blocked (you're on it)."
+        enforce "$MODE" "Pushing to protected branch '${BRANCH}' is blocked (you're on it)."
       fi
     fi
   fi
 fi
 
 # 4. No commit on protected branch
-if [[ "$(rule_enabled no-commit-on-protected)" == "true" ]]; then
+MODE=$(rule_mode no-commit-on-protected)
+if rule_active "$MODE"; then
   if printf '%s' "$SCAN" | grep -qE '\bgit\s+commit\b'; then
     BRANCH=$(current_branch)
     if [[ -n "$BRANCH" ]] && is_protected "$BRANCH"; then
-      block "Committing directly to protected branch '${BRANCH}' is blocked. Create a feature branch first."
+      enforce "$MODE" "Committing directly to protected branch '${BRANCH}' is blocked. Create a feature branch first."
     fi
   fi
 fi
 
 # 5. No reset --hard
-if [[ "$(rule_enabled no-reset-hard)" == "true" ]]; then
+MODE=$(rule_mode no-reset-hard)
+if rule_active "$MODE"; then
   if printf '%s' "$SCAN" | grep -qE '\bgit\s+reset\b.*--hard\b'; then
-    block "git reset --hard is blocked. Use git stash or git reset --soft instead."
+    enforce "$MODE" "git reset --hard is blocked. Use git stash or git reset --soft instead."
   fi
 fi
 
 # 6. No discard all changes
-if [[ "$(rule_enabled no-discard-all)" == "true" ]]; then
+MODE=$(rule_mode no-discard-all)
+if rule_active "$MODE"; then
   # git checkout . / git checkout -- .
   if printf '%s' "$SCAN" | grep -qE '\bgit\s+checkout\s+(--\s+)?\.(\s|$)'; then
-    block "git checkout . is blocked (discards all changes). Stage and commit your work, or use git stash."
+    enforce "$MODE" "git checkout . discards all changes. Stage and commit your work, or use git stash."
   fi
   # git restore .
   if printf '%s' "$SCAN" | grep -qE '\bgit\s+restore\s+\.(\s|$)'; then
-    block "git restore . is blocked (discards all changes). Stage and commit your work, or use git stash."
+    enforce "$MODE" "git restore . discards all changes. Stage and commit your work, or use git stash."
   fi
   # git clean -f / git clean -fd
   if printf '%s' "$SCAN" | grep -qE '\bgit\s+clean\b.*-[a-zA-Z]*f'; then
-    block "git clean -f is blocked (deletes untracked files). Review files manually first."
+    enforce "$MODE" "git clean -f deletes untracked files. Review files manually first."
   fi
 fi
 
 # 7. No rebase on protected branch
-if [[ "$(rule_enabled no-rebase-on-protected)" == "true" ]]; then
+MODE=$(rule_mode no-rebase-on-protected)
+if rule_active "$MODE"; then
   if printf '%s' "$SCAN" | grep -qE '\bgit\s+rebase\b'; then
     BRANCH=$(current_branch)
     if [[ -n "$BRANCH" ]] && is_protected "$BRANCH"; then
-      block "Rebasing while on protected branch '${BRANCH}' is blocked. Switch to a feature branch first."
+      enforce "$MODE" "Rebasing while on protected branch '${BRANCH}' is blocked. Switch to a feature branch first."
     fi
   fi
 fi
 
 # 8. No add all (require explicit file paths)
-if [[ "$(rule_enabled no-add-all)" == "true" ]]; then
+MODE=$(rule_mode no-add-all)
+if rule_active "$MODE"; then
   # git add -A / git add --all
   if printf '%s' "$SCAN" | grep -qE '\bgit\s+add\s+(-A\b|--all\b)'; then
-    block "git add -A / --all is blocked. Stage specific files by name."
+    enforce "$MODE" "git add -A / --all is blocked. Stage specific files by name."
   fi
   # git add . (but not git add ./specific/path)
   if printf '%s' "$SCAN" | grep -qE '\bgit\s+add\s+\.(\s|$)'; then
-    block "git add . is blocked. Stage specific files by name."
+    enforce "$MODE" "git add . is blocked. Stage specific files by name."
   fi
 fi
 


### PR DESCRIPTION
## Summary

All rules now support three modes instead of boolean on/off. Closes #19.

| Mode | Effect |
|------|--------|
| `"deny"` / `true` | Hard block — tool call prevented |
| `"ask"` | Prompt user for confirmation |
| `false` | Disabled |

Key changes:
- `rule_enabled()` → `rule_mode()` returning the raw mode string
- `enforce()` helper routes to `deny()` or `ask()` based on mode
- `rule_active()` helper checks if a rule is not disabled
- Fixed jq `//` operator treating `false` as falsy — now uses `has()` to distinguish "key absent" from "key set to false"
- `block()` alias removed — all call sites use `enforce()`
- Default rules changed from `true` to `"deny"` (functionally identical)
- README updated with tri-state documentation

## Test plan

- [x] Default mode (`"deny"`) → tool call denied
- [x] `"ask"` mode → outputs `permissionDecision: "ask"`
- [x] `false` mode → tool call allowed (no output)
- [x] `true` (backward compat) → maps to deny
- [x] Absent key → falls through to default (`"deny"`)
- [x] All existing rules (amend, force push, reset hard, etc.) still work
- [x] Safe commands still allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)