### PR TITLE
refactor: strict tri-state — deny/ask/allow, reject invalid values

### DIFF
--- a/plugins/git-governor/README.md
+++ b/plugins/git-governor/README.md
@@ -56,11 +56,11 @@ Every rule supports three modes:
 
 | Mode | Effect |
 |------|--------|
-| `"deny"` / `true` | Hard block — tool call is prevented |
+| `"deny"` | Hard block — tool call is prevented |
 | `"ask"` | Prompt the user for confirmation before proceeding |
 | `false` | Disabled — no check performed |
 
-Use `"deny"` for operations that should never happen (force push, reset --hard). Use `"ask"` for operations where you want a human checkpoint (committing on protected, discarding changes). Backward compatible: `true` still works as an alias for `"deny"`.
+Use `"deny"` for operations that should never happen (force push, reset --hard). Use `"ask"` for operations where you want a human checkpoint (committing on protected, discarding changes).
 
 ## License
 

--- a/plugins/git-governor/README.md
+++ b/plugins/git-governor/README.md
@@ -14,7 +14,7 @@ A Claude Code plugin that enforces git governance via PreToolUse hooks. Install 
 | `no-discard-all` | deny | Block `git checkout .`, `git restore .`, `git clean -f` |
 | `no-rebase-on-protected` | deny | Block `git rebase` while on a protected branch |
 | `no-add-all` | deny | Block `git add .` and `git add -A` (require explicit file paths) |
-| `require-git-repo` | **off** | Block `Write`/`Edit` to files outside a git repo (opt-in) |
+| `require-git-repo` | **allow** | Block `Write`/`Edit` to files outside a git repo (opt-in) |
 
 Protected branches default to `main` and `master`.
 
@@ -41,7 +41,7 @@ Drop a `.claude/git-governor.json` in your project root to override defaults:
     "no-push-to-protected": "deny",
     "no-reset-hard": "deny",
     "no-discard-all": "ask",
-    "no-rebase-on-protected": false,
+    "no-rebase-on-protected": "allow",
     "no-add-all": "ask",
     "require-git-repo": "deny"
   }
@@ -58,9 +58,9 @@ Every rule supports three modes:
 |------|--------|
 | `"deny"` | Hard block — tool call is prevented |
 | `"ask"` | Prompt the user for confirmation before proceeding |
-| `false` | Disabled — no check performed |
+| `"allow"` | Disabled — no check performed |
 
-Use `"deny"` for operations that should never happen (force push, reset --hard). Use `"ask"` for operations where you want a human checkpoint (committing on protected, discarding changes).
+Use `"deny"` for operations that should never happen (force push, reset --hard). Use `"ask"` for operations where you want a human checkpoint (committing on protected, discarding changes). Invalid values are treated as errors and blocked.
 
 ## License
 

--- a/plugins/git-governor/hooks/git-governor.sh
+++ b/plugins/git-governor/hooks/git-governor.sh
@@ -20,7 +20,7 @@ DEFAULT_RULES='{
   "no-discard-all": "deny",
   "no-rebase-on-protected": "deny",
   "no-add-all": "deny",
-  "require-git-repo": false
+  "require-git-repo": "allow"
 }'
 
 # Load project config if present
@@ -29,7 +29,7 @@ if [[ -f "$CONFIG_FILE" ]]; then
   PROTECTED_BRANCHES=$(jq -c '.["protected-branches"] // '"$DEFAULT_PROTECTED_BRANCHES" "$CONFIG_FILE")
   rule_mode() {
     local val
-    # Use has() to distinguish "key absent" from "key set to false"
+    # Use has() to distinguish "key absent" from "key set to allow"
     if jq -e ".rules | has(\"$1\")" "$CONFIG_FILE" > /dev/null 2>&1; then
       val=$(jq -r ".rules[\"$1\"]" "$CONFIG_FILE")
     else
@@ -69,20 +69,21 @@ ask() {
   exit 0
 }
 
-# Enforce a rule based on its mode: "deny" → deny, "ask" → ask
+# Enforce a rule: "deny" → block, "ask" → prompt user, "allow" → skip
 enforce() {
   local mode="$1" reason="$2"
   case "$mode" in
     deny) deny "$reason" ;;
     ask)  ask "$reason" ;;
-    *)    return ;;
+    allow) return ;;
+    *) deny "Invalid rule mode '${mode}'. Valid values: deny, ask, allow." ;;
   esac
 }
 
-# Check if a rule is active (anything other than false/null)
+# Check if a rule is active (not "allow")
 rule_active() {
   local mode="$1"
-  [[ "$mode" != "false" ]] && [[ "$mode" != "null" ]] && [[ -n "$mode" ]]
+  [[ "$mode" != "allow" ]]
 }
 
 # --- Write|Edit rules ---

--- a/plugins/git-governor/hooks/git-governor.sh
+++ b/plugins/git-governor/hooks/git-governor.sh
@@ -69,13 +69,13 @@ ask() {
   exit 0
 }
 
-# Enforce a rule based on its mode: "deny" / true → deny, "ask" → ask, false → skip
+# Enforce a rule based on its mode: "deny" → deny, "ask" → ask
 enforce() {
   local mode="$1" reason="$2"
   case "$mode" in
-    deny|true) deny "$reason" ;;
-    ask)       ask "$reason" ;;
-    *)         return ;;
+    deny) deny "$reason" ;;
+    ask)  ask "$reason" ;;
+    *)    return ;;
   esac
 }
 

--- a/plugins/git-governor/test.sh
+++ b/plugins/git-governor/test.sh
@@ -275,13 +275,13 @@ run_hook "$(write_input "$NO_GIT_DIR/file.txt" "$NO_GIT_DIR")"
 expect_allow "allows write outside git (rule off by default)"
 
 # Enable rule
-set_config '{"rules":{"require-git-repo":true}}'
+set_config '{"rules":{"require-git-repo":"deny"}}'
 run_hook "$(write_input "$TEST_DIR/file.txt")"
 expect_allow "allows write inside git repo"
 
 # Write outside git with rule on — need config in non-git dir
 mkdir -p "$NO_GIT_DIR/.claude"
-echo '{"rules":{"require-git-repo":true}}' > "$NO_GIT_DIR/.claude/git-governor.json"
+echo '{"rules":{"require-git-repo":"deny"}}' > "$NO_GIT_DIR/.claude/git-governor.json"
 run_hook "$(write_input "$NO_GIT_DIR/file.txt" "$NO_GIT_DIR")"
 expect_deny "blocks write outside git repo (rule on)"
 
@@ -323,7 +323,8 @@ teardown
 printf "\n${BOLD}Config override${RESET}\n"
 setup
 
-# Disable a rule via config
+# Disable a rule via config (on feature branch to avoid no-commit-on-protected)
+git -C "$TEST_DIR" checkout -b feature -q
 set_config '{"rules":{"no-amend":false}}'
 run_hook "$(bash_input 'git commit --amend')"
 expect_allow "allows amend when rule disabled"

--- a/plugins/git-governor/test.sh
+++ b/plugins/git-governor/test.sh
@@ -325,7 +325,7 @@ setup
 
 # Disable a rule via config (on feature branch to avoid no-commit-on-protected)
 git -C "$TEST_DIR" checkout -b feature -q
-set_config '{"rules":{"no-amend":false}}'
+set_config '{"rules":{"no-amend":"allow"}}'
 run_hook "$(bash_input 'git commit --amend')"
 expect_allow "allows amend when rule disabled"
 clear_config


### PR DESCRIPTION
## Summary

- **Strict tri-state values**: all rules accept only `"deny"`, `"ask"`, or `"allow"`. Invalid values are denied with a descriptive error message.
- **No backward compat**: boolean `true`/`false` are no longer accepted. `false` is replaced by `"allow"` throughout.
- **Test fix**: "allows amend when rule disabled" was failing because the test ran on `master` (protected branch), so `no-commit-on-protected` fired even though `no-amend` was correctly disabled. Fixed by switching to a feature branch.

## Test plan

- [x] 45/45 tests pass
- [x] `"deny"` blocks tool calls
- [x] `"ask"` prompts user
- [x] `"allow"` disables rule
- [x] Invalid values are denied with error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
