### PR TITLE
feat: add /git-governor:config skill and global config support

### DIFF
--- a/plugins/git-governor/README.md
+++ b/plugins/git-governor/README.md
@@ -29,7 +29,17 @@ The `require-git-repo` rule blocks file edits to paths that aren't inside a git 
 
 ## Configuration
 
-Drop a `.claude/git-governor.json` in your project root to override defaults:
+Configure interactively with the built-in skill:
+
+```
+/git-governor:config status                       # show effective config
+/git-governor:config set no-amend ask             # set a rule
+/git-governor:config set no-add-all allow --global  # set globally
+/git-governor:config protect release/*            # add protected branch
+/git-governor:config reset                        # remove project config
+```
+
+Or drop a `.claude/git-governor.json` in your project root to override defaults:
 
 ```json
 {
@@ -61,6 +71,16 @@ Every rule supports three modes:
 | `"allow"` | Disabled — no check performed |
 
 Use `"deny"` for operations that should never happen (force push, reset --hard). Use `"ask"` for operations where you want a human checkpoint (committing on protected, discarding changes). Invalid values are treated as errors and blocked.
+
+### Config precedence
+
+| Scope | Path | Precedence |
+|-------|------|------------|
+| Project | `<project>/.claude/git-governor.json` | Highest |
+| Global | `~/.claude/git-governor.json` | Middle |
+| Defaults | Built into the hook | Lowest |
+
+For rules, each rule is resolved independently: project > global > default. For `protected-branches`, the first config that defines the key wins entirely (no merging).
 
 ## License
 

--- a/plugins/git-governor/hooks/git-governor.sh
+++ b/plugins/git-governor/hooks/git-governor.sh
@@ -23,26 +23,31 @@ DEFAULT_RULES='{
   "require-git-repo": "allow"
 }'
 
-# Load project config if present
-CONFIG_FILE="${CWD:-.}/.claude/git-governor.json"
-if [[ -f "$CONFIG_FILE" ]]; then
-  PROTECTED_BRANCHES=$(jq -c '.["protected-branches"] // '"$DEFAULT_PROTECTED_BRANCHES" "$CONFIG_FILE")
-  rule_mode() {
-    local val
-    # Use has() to distinguish "key absent" from "key set to allow"
-    if jq -e ".rules | has(\"$1\")" "$CONFIG_FILE" > /dev/null 2>&1; then
-      val=$(jq -r ".rules[\"$1\"]" "$CONFIG_FILE")
-    else
-      val=$(echo "$DEFAULT_RULES" | jq -r ".[\"$1\"]")
-    fi
-    echo "$val"
-  }
+# Load config: project > global > defaults
+PROJECT_CONFIG="${CWD:-.}/.claude/git-governor.json"
+GLOBAL_CONFIG="${HOME}/.claude/git-governor.json"
+
+# Protected branches: first config that defines them wins
+if [[ -f "$PROJECT_CONFIG" ]] && jq -e '.["protected-branches"]' "$PROJECT_CONFIG" > /dev/null 2>&1; then
+  PROTECTED_BRANCHES=$(jq -c '.["protected-branches"]' "$PROJECT_CONFIG")
+elif [[ -f "$GLOBAL_CONFIG" ]] && jq -e '.["protected-branches"]' "$GLOBAL_CONFIG" > /dev/null 2>&1; then
+  PROTECTED_BRANCHES=$(jq -c '.["protected-branches"]' "$GLOBAL_CONFIG")
 else
   PROTECTED_BRANCHES="$DEFAULT_PROTECTED_BRANCHES"
-  rule_mode() {
-    echo "$DEFAULT_RULES" | jq -r ".[\"$1\"]"
-  }
 fi
+
+# Rule mode: project > global > default
+rule_mode() {
+  local val
+  if [[ -f "$PROJECT_CONFIG" ]] && jq -e ".rules | has(\"$1\")" "$PROJECT_CONFIG" > /dev/null 2>&1; then
+    val=$(jq -r ".rules[\"$1\"]" "$PROJECT_CONFIG")
+  elif [[ -f "$GLOBAL_CONFIG" ]] && jq -e ".rules | has(\"$1\")" "$GLOBAL_CONFIG" > /dev/null 2>&1; then
+    val=$(jq -r ".rules[\"$1\"]" "$GLOBAL_CONFIG")
+  else
+    val=$(echo "$DEFAULT_RULES" | jq -r ".[\"$1\"]")
+  fi
+  echo "$val"
+}
 
 # Convert protected branches JSON array to a bash-friendly check
 is_protected() {

--- a/plugins/git-governor/skills/config/SKILL.md
+++ b/plugins/git-governor/skills/config/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: config
+description: >
+  Configure git-governor rules and protected branches. Use when the user
+  invokes /git-governor:config to set rule modes (deny/ask/allow), view
+  effective configuration, manage protected branch patterns, or reset config.
+---
+
+# git-governor config
+
+Interactive configuration for the git-governor plugin.
+
+## Usage
+
+```
+/git-governor:config <command> [args] [--global]
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `status` | Show effective config with source of each value |
+| `set <rule> <mode>` | Set a rule's mode |
+| `protect <pattern>` | Add a protected branch pattern |
+| `unprotect <pattern>` | Remove a protected branch pattern |
+| `reset` | Delete the config file |
+
+The `--global` flag targets `~/.claude/git-governor.json` instead of the project config.
+
+## Config file locations
+
+| Scope | Path | Precedence |
+|-------|------|------------|
+| Project | `<project>/.claude/git-governor.json` | Highest (wins) |
+| Global | `~/.claude/git-governor.json` | Middle |
+| Defaults | Built into the hook | Lowest |
+
+For rules: project overrides global overrides defaults.
+For protected branches: the first config that defines `protected-branches` wins entirely (no merging).
+
+## Valid rules
+
+| Rule | Default |
+|------|---------|
+| `no-amend` | `deny` |
+| `no-commit-on-protected` | `deny` |
+| `no-push-to-protected` | `deny` |
+| `no-force-push` | `deny` |
+| `no-reset-hard` | `deny` |
+| `no-discard-all` | `deny` |
+| `no-rebase-on-protected` | `deny` |
+| `no-add-all` | `deny` |
+| `require-git-repo` | `allow` |
+
+## Valid modes
+
+| Mode | Effect |
+|------|--------|
+| `"deny"` | Hard block — tool call prevented |
+| `"ask"` | Prompt user for confirmation |
+| `"allow"` | Disabled — no check |
+
+## Instructions
+
+ARGUMENTS: provided after the skill name, e.g. `/git-governor:config status`
+
+### Command: `status`
+
+1. Read defaults (use the table above).
+2. Read global config at `~/.claude/git-governor.json` if it exists.
+3. Read project config at `<CWD>/.claude/git-governor.json` if it exists.
+4. Compute the effective value for each rule using merge precedence: project > global > default.
+5. Display a table with columns: Rule, Effective Mode, Source (default/global/project).
+6. Display the effective protected branches and their source.
+
+Example output:
+```
+| Rule                      | Mode  | Source  |
+|---------------------------|-------|---------|
+| no-amend                  | deny  | default |
+| no-commit-on-protected    | ask   | project |
+| no-push-to-protected      | deny  | global  |
+| no-force-push             | deny  | default |
+| no-reset-hard             | deny  | default |
+| no-discard-all            | ask   | project |
+| no-rebase-on-protected    | deny  | default |
+| no-add-all                | deny  | default |
+| require-git-repo          | allow | default |
+
+Protected branches: ["main", "master"] (default)
+```
+
+### Command: `set <rule> <mode>`
+
+1. Validate `<rule>` against the valid rules list. If invalid, show the valid rules and stop.
+2. Validate `<mode>` against: `deny`, `ask`, `allow`. If invalid, show valid modes and stop.
+3. Determine target file:
+   - Without `--global`: `<CWD>/.claude/git-governor.json`
+   - With `--global`: `~/.claude/git-governor.json`
+4. Read the target file. If it doesn't exist, start with `{}`.
+5. Set `.rules.<rule>` to the mode value (as a string).
+6. Ensure the `.rules` object exists in the JSON.
+7. Create the parent directory if needed (`mkdir -p` via Bash).
+8. Write the complete JSON back with 2-space indentation.
+9. Confirm: `Set <rule> = "<mode>" in <scope> config.`
+
+### Command: `protect <pattern>`
+
+1. Determine target file (project or global based on `--global`).
+2. Read the target file. If it doesn't exist, start with `{}`.
+3. Read the current `protected-branches` array. If absent, start with `[]`.
+4. If the pattern is already in the array, inform the user and stop.
+5. Append the pattern to the array.
+6. Write the complete JSON back with 2-space indentation.
+7. Confirm and show the resulting protected branches list.
+
+### Command: `unprotect <pattern>`
+
+1. Determine target file (project or global based on `--global`).
+2. Read the target file. If it doesn't exist, inform the user there's nothing to change.
+3. Read the current `protected-branches` array. If absent, inform the user.
+4. If the pattern is not in the array, inform the user and stop.
+5. Remove the pattern from the array.
+6. If the array is now empty, remove the `protected-branches` key entirely.
+7. Write the complete JSON back with 2-space indentation.
+8. Confirm and show the resulting protected branches list.
+
+### Command: `reset`
+
+1. Determine target file (project or global based on `--global`).
+2. If the file doesn't exist, inform the user there's nothing to reset.
+3. Delete the file using Bash `rm`.
+4. Confirm: `Deleted <scope> config. Defaults will be used.`
+
+### No command or `help`
+
+If invoked with no arguments or with `help`, display the usage summary showing all commands, valid rules, and valid modes.
+
+### JSON handling
+
+- Always use the Read tool to read config files before modifying.
+- Always use the Write tool to write the complete JSON content (not Edit, since the changes may restructure the object).
+- Use 2-space indentation in JSON output.
+- Preserve any existing keys that are not being modified.
+- Use `jq` via Bash for JSON manipulation if needed, but prefer reading and writing via the dedicated tools.

--- a/plugins/git-governor/test.sh
+++ b/plugins/git-governor/test.sh
@@ -53,6 +53,13 @@ run_hook() {
   EXIT_CODE=${PIPESTATUS[1]:-0}
 }
 
+# Run hook with a custom HOME (for global config tests)
+run_hook_with_home() {
+  local input="$1" fake_home="$2"
+  OUTPUT=$(echo "$input" | HOME="$fake_home" bash "$HOOK" 2>/dev/null) || true
+  EXIT_CODE=${PIPESTATUS[1]:-0}
+}
+
 # Extract permissionDecision from output
 get_decision() {
   echo "$OUTPUT" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null || true
@@ -339,6 +346,50 @@ run_hook "$(bash_input 'git push origin develop')"
 expect_allow "allows push to non-protected branch"
 
 clear_config
+teardown
+
+# ============================================================
+printf "\n${BOLD}Global config${RESET}\n"
+setup
+FAKE_HOME=$(mktemp -d)
+
+# Global config only: allow amend globally
+git -C "$TEST_DIR" checkout -b feature -q
+mkdir -p "$FAKE_HOME/.claude"
+echo '{"rules":{"no-amend":"allow"}}' > "$FAKE_HOME/.claude/git-governor.json"
+run_hook_with_home "$(bash_input 'git commit --amend')" "$FAKE_HOME"
+expect_allow "global config: allows amend when set to allow"
+
+# Project overrides global: global=allow, project=deny
+set_config '{"rules":{"no-amend":"deny"}}'
+run_hook_with_home "$(bash_input 'git commit --amend')" "$FAKE_HOME"
+expect_deny "project overrides global: deny beats allow"
+clear_config
+
+# Global protected branches
+echo '{"protected-branches":["main","staging"]}' > "$FAKE_HOME/.claude/git-governor.json"
+run_hook_with_home "$(bash_input 'git push origin staging')" "$FAKE_HOME"
+expect_deny "global config: blocks push to globally-protected branch"
+
+# Project overrides global protected branches
+set_config '{"protected-branches":["main"]}'
+run_hook_with_home "$(bash_input 'git push origin staging')" "$FAKE_HOME"
+expect_allow "project overrides global protected branches"
+clear_config
+
+rm -rf "$FAKE_HOME"
+teardown
+
+# ============================================================
+printf "\n${BOLD}Invalid config values${RESET}\n"
+setup
+git -C "$TEST_DIR" checkout -b feature -q
+
+set_config '{"rules":{"no-amend":"bogus"}}'
+run_hook "$(bash_input 'git commit --amend')"
+expect_deny "invalid mode value is denied with error"
+clear_config
+
 teardown
 
 # ============================================================


### PR DESCRIPTION
## Summary

Closes #23. Two changes:

**1. Global config support in hook script**

Config resolution is now three-tier: project > global > defaults.
- Project: `<project>/.claude/git-governor.json`
- Global: `~/.claude/git-governor.json`
- Rules resolved independently per-rule. Protected branches: first config that defines the key wins entirely.

**2. Interactive config skill (`/git-governor:config`)**

| Command | Description |
|---------|-------------|
| `status` | Show effective config with source of each value |
| `set <rule> <mode>` | Set a rule mode (deny/ask/allow) |
| `protect <pattern>` | Add protected branch pattern |
| `unprotect <pattern>` | Remove protected branch pattern |
| `reset` | Delete config file |

All commands support `--global` flag.

## Test plan

- [x] 50/50 tests pass
- [x] Global config only: rules respected
- [x] Project overrides global for rules
- [x] Global protected branches respected
- [x] Project overrides global protected branches
- [x] Invalid config values denied with error
- [x] All existing rules still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)