### PR TITLE
release: git-governor 2.0.0

### DIFF
--- a/plugins/git-governor/.claude-plugin/plugin.json
+++ b/plugins/git-governor/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "git-governor",
-  "version": "1.0.0",
-  "description": "Enforce git governance — block amends, direct commits to protected branches, force pushes, and destructive resets",
+  "version": "2.0.0",
+  "description": "Enforce git governance — block or prompt on amends, direct commits to protected branches, force pushes, destructive resets, and more",
   "author": {
     "name": "Luka Kladarić",
     "url": "https://github.com/allixsenos"


### PR DESCRIPTION
## git-governor 2.0.0

### Breaking changes
- Rule modes are now `"deny"`, `"ask"`, or `"allow"` — boolean `true`/`false` removed
- Hook output uses modern `hookSpecificOutput` protocol — deprecated `{"decision":"block"}` format removed

### New features
- **Tri-state rule config**: `"deny"` (hard block), `"ask"` (prompt user for confirmation), `"allow"` (disable)
- **`no-add-all` rule**: blocks `git add .` and `git add -A`, requires explicit file paths
- **Global config**: `~/.claude/git-governor.json` with project > global > defaults precedence
- **`/git-governor:config` skill**: interactive configuration (set, status, protect, unprotect, reset)
- **False positive prevention**: heredoc and quoted string content no longer triggers rule checks
- **Invalid value rejection**: unknown rule modes are denied with a descriptive error

### Test suite
50 tests covering all rules, config merging, false positive prevention, and protocol format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)