### PR TITLE
release: git-governor 2.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent-plugins",
+  "name": "allixsenos-agent-plugins",
   "description": "Agent plugins by allixsenos",
   "owner": {
     "name": "allixsenos",
@@ -9,8 +9,8 @@
     {
       "name": "git-governor",
       "source": "./plugins/git-governor",
-      "description": "Enforce git governance — block amends, direct commits to protected branches, force pushes, and destructive resets",
-      "version": "1.0.0"
+      "description": "Enforce git governance — block or prompt on amends, direct commits to protected branches, force pushes, destructive resets, and more",
+      "version": "2.0.0"
     }
   ]
 }

--- a/plugins/git-governor/.claude-plugin/plugin.json
+++ b/plugins/git-governor/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "git-governor",
-  "version": "1.0.0",
-  "description": "Enforce git governance — block amends, direct commits to protected branches, force pushes, and destructive resets",
+  "version": "2.0.0",
+  "description": "Enforce git governance — block or prompt on amends, direct commits to protected branches, force pushes, destructive resets, and more",
   "author": {
     "name": "Luka Kladarić",
     "url": "https://github.com/allixsenos"


### PR DESCRIPTION
## Summary
- Bump plugin version to 2.0.0 in both `plugin.json` and `marketplace.json`
- Rename marketplace from `agent-plugins` to `allixsenos-agent-plugins`
- Update description to reflect tri-state rule support

Fixes marketplace serving stale 1.0.0 instead of 2.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)