### PR TITLE
fix: marketplace source path validation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "git-governor",
-      "source": ".",
+      "source": "./",
       "description": "Enforce git governance — block or prompt on amends, direct commits to protected branches, force pushes, destructive resets, and more",
       "version": "2.0.1"
     }


### PR DESCRIPTION
## Summary
- Change source from `"."` to `"./"` to pass CLI schema validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)