### PR TITLE
feat: adversarial test suite and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Configure git identity
+        run: |
+          git config --global user.email "ci@test.local"
+          git config --global user.name "CI"
+
       - name: Install jq
         run: sudo apt-get install -y jq
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
+      - name: Run governance tests
+        run: bash test.sh
+
+      - name: Run adversarial tests
+        run: bash test-adversarial.sh

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Claude Code plugin that enforces git governance via PreToolUse hooks. Install 
 |------|---------|-------------|
 | `no-amend` | deny | Block `git commit --amend` |
 | `no-commit-on-protected` | deny | Block `git commit` on protected branches |
-| `no-push-to-protected` | deny | Block `git push` targeting protected branches |
+| `no-push-to-protected` | **ask** | Prompt before `git push` targeting protected branches |
 | `no-force-push` | deny | Block `--force`, `--force-with-lease`, `+refs` push syntax |
 | `no-reset-hard` | deny | Block `git reset --hard` |
 | `no-discard-all` | deny | Block `git checkout .`, `git restore .`, `git clean -f` |
@@ -48,7 +48,7 @@ Or drop a `.claude/git-governor.json` in your project root to override defaults:
     "no-amend": "deny",
     "no-force-push": "deny",
     "no-commit-on-protected": "ask",
-    "no-push-to-protected": "deny",
+    "no-push-to-protected": "ask",
     "no-reset-hard": "deny",
     "no-discard-all": "ask",
     "no-rebase-on-protected": "allow",

--- a/skills/git-governor/SKILL.md
+++ b/skills/git-governor/SKILL.md
@@ -45,7 +45,7 @@ For protected branches: the first config that defines `protected-branches` wins 
 |------|---------|-------------|
 | `no-amend` | `deny` | Block `git commit --amend` |
 | `no-commit-on-protected` | `deny` | Block commits directly on protected branches |
-| `no-push-to-protected` | `deny` | Block pushing to protected branches |
+| `no-push-to-protected` | `ask` | Prompt before pushing to protected branches |
 | `no-force-push` | `deny` | Block `--force`, `--force-with-lease`, and `+refspec` pushes |
 | `no-reset-hard` | `deny` | Block `git reset --hard` |
 | `no-discard-all` | `deny` | Block `git checkout .`, `git restore .`, `git clean -f` |
@@ -84,7 +84,7 @@ Example output:
 |-------------------------|-------------------------------------|---------|--------|---------|-----------|
 | no-amend                | Block git commit --amend            | deny    | -      | ask     | ask       |
 | no-commit-on-protected  | Block commits on protected branches | deny    | -      | -       | deny      |
-| no-push-to-protected    | Block pushing to protected branches | deny    | deny   | -       | deny      |
+| no-push-to-protected    | Prompt before pushing to protected  | ask     | deny   | -       | deny      |
 | no-force-push           | Block force push                    | deny    | -      | -       | deny      |
 | no-reset-hard           | Block git reset --hard              | deny    | -      | -       | deny      |
 | no-discard-all          | Block checkout/restore/clean all    | deny    | -      | allow   | allow     |

--- a/test-adversarial.sh
+++ b/test-adversarial.sh
@@ -1,0 +1,422 @@
+#!/usr/bin/env bash
+# git-governor adversarial / fuzzing test suite
+#
+# Tests evasion techniques that might bypass governance rules.
+# Each section targets a specific attack vector. Tests marked "KNOWN GAP"
+# document bypasses that are accepted risks (shell indirection, etc).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$SCRIPT_DIR/hooks/git-governor.sh"
+PASS=0
+FAIL=0
+TOTAL=0
+
+# Colors
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+# --- Test helpers (same as test.sh) ---
+
+setup() {
+  TEST_DIR=$(mktemp -d)
+  git init -q "$TEST_DIR"
+  git -C "$TEST_DIR" commit --allow-empty -m "init" -q
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+bash_input() {
+  local cmd="$1" cwd="${2:-$TEST_DIR}"
+  jq -n --arg cmd "$cmd" --arg cwd "$cwd" \
+    '{tool_name:"Bash",tool_input:{command:$cmd},cwd:$cwd}'
+}
+
+run_hook() {
+  local input="$1"
+  OUTPUT=$(echo "$input" | bash "$HOOK" 2>/dev/null) || true
+  EXIT_CODE=${PIPESTATUS[1]:-0}
+}
+
+run_hook_with_home() {
+  local input="$1" fake_home="$2"
+  OUTPUT=$(echo "$input" | HOME="$fake_home" bash "$HOOK" 2>/dev/null) || true
+  EXIT_CODE=${PIPESTATUS[1]:-0}
+}
+
+get_decision() {
+  echo "$OUTPUT" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null || true
+}
+
+expect_deny() {
+  local label="$1"
+  TOTAL=$((TOTAL + 1))
+  local decision
+  decision=$(get_decision)
+  if [[ "$decision" == "deny" ]]; then
+    PASS=$((PASS + 1))
+    printf "  ${GREEN}PASS${RESET} %s\n" "$label"
+  else
+    FAIL=$((FAIL + 1))
+    printf "  ${RED}FAIL${RESET} %s (expected deny, got '%s')\n" "$label" "$decision"
+  fi
+}
+
+expect_blocked() {
+  # Accept either "deny" or "ask" — the point is it wasn't silently allowed
+  local label="$1"
+  TOTAL=$((TOTAL + 1))
+  local decision
+  decision=$(get_decision)
+  if [[ "$decision" == "deny" || "$decision" == "ask" ]]; then
+    PASS=$((PASS + 1))
+    printf "  ${GREEN}PASS${RESET} %s (got '%s')\n" "$label" "$decision"
+  else
+    FAIL=$((FAIL + 1))
+    printf "  ${RED}FAIL${RESET} %s (expected deny/ask, got '%s')\n" "$label" "$decision"
+  fi
+}
+
+expect_allow() {
+  local label="$1"
+  TOTAL=$((TOTAL + 1))
+  local decision
+  decision=$(get_decision)
+  if [[ -z "$decision" ]]; then
+    PASS=$((PASS + 1))
+    printf "  ${GREEN}PASS${RESET} %s\n" "$label"
+  else
+    FAIL=$((FAIL + 1))
+    printf "  ${RED}FAIL${RESET} %s (expected allow, got '%s')\n" "$label" "$decision"
+  fi
+}
+
+# Known gap: document a bypass that we accept as out-of-scope
+known_gap() {
+  local label="$1"
+  TOTAL=$((TOTAL + 1))
+  local decision
+  decision=$(get_decision)
+  if [[ -z "$decision" ]]; then
+    PASS=$((PASS + 1))
+    printf "  ${YELLOW}SKIP${RESET} %s (known gap — bypasses as expected)\n" "$label"
+  else
+    # If it's actually caught, even better
+    PASS=$((PASS + 1))
+    printf "  ${GREEN}PASS${RESET} %s (caught despite being a known gap!)\n" "$label"
+  fi
+}
+
+set_config() {
+  local config="$1"
+  mkdir -p "$TEST_DIR/.claude"
+  echo "$config" > "$TEST_DIR/.claude/git-governor.json"
+}
+
+clear_config() {
+  rm -f "$TEST_DIR/.claude/git-governor.json"
+}
+
+# ============================================================
+printf "${BOLD}git-governor adversarial test suite${RESET}\n"
+
+# ============================================================
+printf "\n${BOLD}1. Git global flags between git and subcommand${RESET}\n"
+setup
+
+run_hook "$(bash_input 'git -C /tmp commit --amend')"
+expect_blocked "git -C <path> commit --amend"
+
+run_hook "$(bash_input 'git -c user.name=x commit --amend')"
+expect_blocked "git -c <key=val> commit --amend"
+
+run_hook "$(bash_input 'git --git-dir=.git commit --amend')"
+expect_blocked "git --git-dir=<path> commit --amend"
+
+run_hook "$(bash_input 'git --work-tree=. commit --amend')"
+expect_blocked "git --work-tree=<path> commit --amend"
+
+run_hook "$(bash_input 'git -C /tmp push --force origin main')"
+expect_blocked "git -C <path> push --force"
+
+run_hook "$(bash_input 'git -C /tmp reset --hard HEAD')"
+expect_blocked "git -C <path> reset --hard"
+
+run_hook "$(bash_input 'git -c core.autocrlf=true add .')"
+expect_blocked "git -c <key=val> add ."
+
+run_hook "$(bash_input 'git -C /tmp -c user.name=x commit --amend')"
+expect_blocked "git -C -c (chained global flags) commit --amend"
+
+teardown
+
+# ============================================================
+printf "\n${BOLD}2. Command chaining (dangerous git after benign command)${RESET}\n"
+setup
+
+run_hook "$(bash_input 'echo done && git push --force origin main')"
+expect_blocked "echo && git push --force"
+
+run_hook "$(bash_input 'true; git commit --amend')"
+expect_blocked "true; git commit --amend"
+
+run_hook "$(bash_input 'ls -la && git reset --hard HEAD')"
+expect_blocked "ls && git reset --hard"
+
+run_hook "$(bash_input 'echo "starting" && git add . && git commit -m "msg"')"
+expect_blocked "echo && git add ."
+
+run_hook "$(bash_input 'npm test || git push --force origin main')"
+expect_blocked "npm test || git push --force"
+
+run_hook "$(bash_input 'git status && git push --force origin main')"
+expect_blocked "git status && git push --force"
+
+teardown
+
+# ============================================================
+printf "\n${BOLD}3. Shell indirection (known gaps)${RESET}\n"
+setup
+
+run_hook "$(bash_input 'eval "git push --force origin main"')"
+known_gap "eval with git push --force"
+
+run_hook "$(bash_input 'cmd=push; git $cmd --force')"
+known_gap "variable expansion: git \$cmd --force"
+
+run_hook "$(bash_input '$(echo git) push --force')"
+known_gap "subshell: \$(echo git) push --force"
+
+run_hook "$(bash_input 'echo "push --force" | xargs git')"
+known_gap "xargs: echo | xargs git"
+
+teardown
+
+# ============================================================
+printf "\n${BOLD}4. Binary path instead of bare git${RESET}\n"
+setup
+
+run_hook "$(bash_input '/usr/bin/git push --force origin main')"
+known_gap "/usr/bin/git push --force"
+
+run_hook "$(bash_input '/usr/bin/git commit --amend')"
+known_gap "/usr/bin/git commit --amend"
+
+teardown
+
+# ============================================================
+printf "\n${BOLD}5. Command wrappers${RESET}\n"
+setup
+
+run_hook "$(bash_input 'env git push --force origin main')"
+known_gap "env git push --force"
+
+run_hook "$(bash_input 'command git push --force origin main')"
+known_gap "command git push --force"
+
+run_hook "$(bash_input 'nice git push --force origin main')"
+known_gap "nice git push --force"
+
+teardown
+
+# ============================================================
+printf "\n${BOLD}6. Sanitizer edge cases${RESET}\n"
+setup
+
+# Backtick expansion (not stripped by the sanitizer)
+run_hook "$(bash_input 'git push `echo --force` origin main')"
+known_gap "backtick expansion: git push \`echo --force\`"
+
+# $() expansion inside the command
+run_hook "$(bash_input 'git push $(echo --force) origin main')"
+known_gap "subshell expansion: git push \$(echo --force)"
+
+# Unbalanced quotes — the sed should still strip what it can
+run_hook "$(bash_input "git commit --amend -m \"it's a fix\"")"
+expect_blocked "unbalanced quote: git commit --amend -m \"it's a fix\""
+
+# Empty quoted strings shouldn't hide adjacent args
+run_hook "$(bash_input "git commit ''--amend")"
+expect_blocked "empty quotes adjacent to --amend"
+
+# Escaped quotes inside strings
+run_hook "$(bash_input 'git push --force origin "ma\"in"')"
+expect_blocked "escaped quotes: git push --force with escaped inner quote"
+
+teardown
+
+# ============================================================
+printf "\n${BOLD}7. Flag reordering${RESET}\n"
+setup
+
+run_hook "$(bash_input 'git push origin main --force')"
+expect_blocked "flag after refspec: git push origin main --force"
+
+run_hook "$(bash_input 'git push -f origin main')"
+expect_blocked "short flag before remote: git push -f origin main"
+
+run_hook "$(bash_input 'git reset HEAD --hard')"
+expect_blocked "flag after ref: git reset HEAD --hard"
+
+run_hook "$(bash_input 'git reset --hard')"
+expect_blocked "bare git reset --hard (no ref)"
+
+run_hook "$(bash_input 'git clean -dfx')"
+expect_blocked "combined flags: git clean -dfx"
+
+run_hook "$(bash_input 'git clean --force -d')"
+expect_blocked "long flag: git clean --force -d"
+
+teardown
+
+# ============================================================
+printf "\n${BOLD}8. Whitespace variations${RESET}\n"
+setup
+
+run_hook "$(bash_input 'git  push  --force  origin  main')"
+expect_blocked "multiple spaces: git  push  --force"
+
+run_hook "$(bash_input 'git	commit	--amend')"
+expect_blocked "tab chars: git<tab>commit<tab>--amend"
+
+run_hook "$(bash_input $'git push \\\n--force origin main')"
+known_gap "line continuation: git push \\\\n--force"
+
+teardown
+
+# ============================================================
+printf "\n${BOLD}9. Config poisoning${RESET}\n"
+setup
+
+# Invalid JSON config — hook should not fail open
+set_config 'NOT VALID JSON {'
+run_hook "$(bash_input 'git commit --amend')"
+expect_blocked "invalid JSON config: still blocks amend"
+clear_config
+
+# Config that tries to set rules to empty string
+set_config '{"rules":{"no-amend":""}}'
+run_hook "$(bash_input 'git commit --amend')"
+expect_blocked "empty string mode: still blocks amend"
+clear_config
+
+# Config with extra unknown fields (should not break)
+set_config '{"rules":{"no-amend":"deny"},"extra_field":"whatever","nested":{"a":1}}'
+run_hook "$(bash_input 'git commit --amend')"
+expect_blocked "extra config fields: still blocks amend"
+clear_config
+
+teardown
+
+# ============================================================
+printf "\n${BOLD}10. Partial keyword matches (false positive prevention)${RESET}\n"
+setup
+git -C "$TEST_DIR" checkout -b feature -q
+
+# Words containing "git" shouldn't trigger
+run_hook "$(bash_input 'echo digit')"
+expect_allow "word containing 'git': digit"
+
+run_hook "$(bash_input 'legitimate command')"
+expect_allow "word containing 'git': legitimate"
+
+# "git" in a path
+run_hook "$(bash_input 'cat /tmp/git-notes.txt')"
+expect_allow "git in a path: /tmp/git-notes.txt"
+
+# Subcommands that are not governed
+run_hook "$(bash_input 'git log --oneline -10')"
+expect_allow "benign subcommand: git log"
+
+run_hook "$(bash_input 'git diff HEAD~1')"
+expect_allow "benign subcommand: git diff"
+
+run_hook "$(bash_input 'git stash pop')"
+expect_allow "benign subcommand: git stash pop"
+
+run_hook "$(bash_input 'git branch -a')"
+expect_allow "benign subcommand: git branch -a"
+
+run_hook "$(bash_input 'git fetch origin')"
+expect_allow "benign subcommand: git fetch"
+
+teardown
+
+# ============================================================
+printf "\n${BOLD}11. Refspec evasion for push-to-protected${RESET}\n"
+setup
+
+run_hook "$(bash_input 'git push origin HEAD:main')"
+expect_blocked "refspec HEAD:main"
+
+run_hook "$(bash_input 'git push origin feature:main')"
+expect_blocked "refspec feature:main"
+
+run_hook "$(bash_input 'git push origin HEAD:refs/heads/main')"
+expect_blocked "refspec HEAD:refs/heads/main"
+
+teardown
+
+# ============================================================
+printf "\n${BOLD}12. Multiple git commands in one line${RESET}\n"
+setup
+
+# First command benign, second dangerous
+run_hook "$(bash_input 'git status; git reset --hard HEAD')"
+expect_blocked "git status; git reset --hard"
+
+# Benign git followed by dangerous via &&
+run_hook "$(bash_input 'git add file.txt && git commit --amend')"
+expect_blocked "git add file && git commit --amend"
+
+# Pipe from git to git (unusual but possible)
+run_hook "$(bash_input 'git log --oneline | head -1 && git push --force')"
+expect_blocked "git log | head && git push --force"
+
+teardown
+
+# ============================================================
+printf "\n${BOLD}13. Heredoc containing real command after${RESET}\n"
+setup
+
+# Heredoc with innocent git text, followed by real dangerous command
+INPUT=$(jq -n --arg cwd "$TEST_DIR" '{tool_name:"Bash",tool_input:{command:("cat > /tmp/notes.md <<'"'"'EOF'"'"'\ngit is great\nEOF\ngit push --force origin main")},cwd:$cwd}')
+run_hook "$INPUT"
+expect_blocked "heredoc then git push --force"
+
+INPUT=$(jq -n --arg cwd "$TEST_DIR" '{tool_name:"Bash",tool_input:{command:("cat <<'"'"'EOF'"'"'\nsome text\nEOF\ngit commit --amend -m \"fix\"")},cwd:$cwd}')
+run_hook "$INPUT"
+expect_blocked "heredoc then git commit --amend"
+
+teardown
+
+# ============================================================
+printf "\n${BOLD}14. gh CLI evasion${RESET}\n"
+setup
+
+# The hook also scans for gh commands (no-merge-pr rule)
+run_hook "$(bash_input 'gh pr merge 123 --squash')"
+expect_blocked "gh pr merge --squash"
+
+run_hook "$(bash_input 'gh pr merge 123 --rebase')"
+expect_blocked "gh pr merge --rebase"
+
+run_hook "$(bash_input 'echo done && gh pr merge 123 --squash')"
+expect_blocked "chained: echo && gh pr merge"
+
+teardown
+
+# ============================================================
+# Summary
+printf "\n${BOLD}Results: ${PASS}/${TOTAL} passed"
+if [[ $FAIL -gt 0 ]]; then
+  printf ", ${RED}${FAIL} failed${RESET}"
+fi
+printf "${RESET}\n"
+
+exit $FAIL

--- a/test.sh
+++ b/test.sh
@@ -165,10 +165,10 @@ printf "\n${BOLD}Rule: no-push-to-protected${RESET}\n"
 setup
 
 run_hook "$(bash_input 'git push origin main')"
-expect_deny "blocks push to main"
+expect_ask "asks before push to main"
 
 run_hook "$(bash_input 'git push origin master')"
-expect_deny "blocks push to master"
+expect_ask "asks before push to master"
 
 run_hook "$(bash_input 'git push origin feature-branch')"
 expect_allow "allows push to feature branch"
@@ -340,7 +340,7 @@ clear_config
 # Custom protected branches
 set_config '{"protected-branches":["main","master","release/*"]}'
 run_hook "$(bash_input 'git push origin release/1.0')"
-expect_deny "blocks push to glob-matched protected branch"
+expect_ask "asks before push to glob-matched protected branch"
 
 run_hook "$(bash_input 'git push origin develop')"
 expect_allow "allows push to non-protected branch"
@@ -369,7 +369,7 @@ clear_config
 # Global protected branches
 echo '{"protected-branches":["main","staging"]}' > "$FAKE_HOME/.claude/git-governor.json"
 run_hook_with_home "$(bash_input 'git push origin staging')" "$FAKE_HOME"
-expect_deny "global config: blocks push to globally-protected branch"
+expect_ask "global config: asks before push to globally-protected branch"
 
 # Project overrides global protected branches
 set_config '{"protected-branches":["main"]}'


### PR DESCRIPTION
## Summary
- Add `test-adversarial.sh` with 59 evasion tests across 14 attack categories (global flags, command chaining, shell indirection, binary paths, wrappers, sanitizer edge cases, flag reordering, whitespace, config poisoning, false positives, refspec evasion, multi-command, heredoc tricks, gh CLI)
- Add GitHub Actions workflow (`.github/workflows/test.yml`) that runs both `test.sh` and `test-adversarial.sh` on PRs and pushes to main
- Fix `no-push-to-protected` docs to match actual default (`ask`, not `deny`) in README.md and SKILL.md
- Fix `test.sh` to expect `ask` for push-to-protected tests (was incorrectly expecting `deny`)

## Test policy
- Both test suites must pass to merge
- Any bug report that doesn't already trip a test must have a failing test written before the fix lands

## Test plan
- [x] `test.sh` passes (50/50)
- [x] `test-adversarial.sh` passes (59/59)
- [x] CI workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)