### PR TITLE
fix: close 5 adversarial evasion gaps

### DIFF
--- a/hooks/git-governor.sh
+++ b/hooks/git-governor.sh
@@ -127,13 +127,33 @@ if [[ -z "$COMMAND" ]]; then
   exit 0
 fi
 
-# Sanitize command: strip heredoc content and quoted strings to prevent
-# false positives from git-related text inside arguments (fixes #16).
+# Sanitize command: strip heredoc content, quoted strings, and handle
+# shell indirection to prevent both false positives and evasion.
 SCAN="$COMMAND"
+
+# Collapse line continuations (backslash-newline) so patterns match
+# across split lines, e.g. "git push \<nl>--force" → "git push --force"
+SCAN=$(printf '%s' "$SCAN" | perl -pe 's/\\\n\s*/ /g')
+
+# Strip heredoc content
 if printf '%s' "$SCAN" | grep -q '<<'; then
   SCAN=$(printf '%s' "$SCAN" | perl -0777 -pe "s/<<~?'?(\w+)'?\s*\n.*?\n\1\b//gs" 2>/dev/null) || SCAN="$COMMAND"
 fi
+
+# Strip quoted strings, but preserve a copy for eval detection.
+# eval "git push --force" hides the payload inside quotes — if we detect
+# eval after stripping, we fall back to the pre-strip version.
+SCAN_BEFORE_QUOTES="$SCAN"
 SCAN=$(printf '%s' "$SCAN" | sed "s/'[^']*'//g" | sed 's/"[^"]*"//g')
+
+if printf '%s' "$SCAN" | grep -qE '\beval\b'; then
+  SCAN="$SCAN_BEFORE_QUOTES"
+fi
+
+# Unwrap subshell and backtick syntax so patterns match through them:
+# $(echo git) push --force → echo git push --force
+# `echo git` push --force  → echo git push --force
+SCAN=$(printf '%s' "$SCAN" | sed 's/\$(\([^)]*\))/\1/g' | sed 's/`\([^`]*\)`/\1/g')
 
 # Strip git global flags (-C <path>, -c <key=val>, --git-dir=<path>, --work-tree=<path>)
 # so "git -C /tmp/foo commit --amend" is scanned as "git commit --amend".
@@ -142,6 +162,16 @@ SCAN=$(printf '%s' "$SCAN" | perl -pe 's/\bgit\s+(?:(?:-[Cc]|--git-dir|--work-tr
 # Quick check: does the sanitized command invoke git or gh?
 if ! printf '%s' "$SCAN" | grep -qE '\b(git|gh)\b'; then
   exit 0
+fi
+
+# Shell indirection: xargs piping args to git — can't verify what runs
+if printf '%s' "$SCAN" | grep -qE '\bxargs\b.*\sgit(\s|$)'; then
+  deny "xargs with git is blocked — cannot verify the git subcommand is safe. Run git commands directly."
+fi
+
+# Shell indirection: variable in git subcommand position — can't verify what runs
+if printf '%s' "$SCAN" | grep -qE '\bgit\s+\$\w+'; then
+  deny "git with a variable subcommand is blocked — cannot verify safety. Run git commands directly."
 fi
 
 # 1. No amend

--- a/test-adversarial.sh
+++ b/test-adversarial.sh
@@ -15,7 +15,6 @@ TOTAL=0
 # Colors
 GREEN='\033[0;32m'
 RED='\033[0;31m'
-YELLOW='\033[0;33m'
 BOLD='\033[1m'
 RESET='\033[0m'
 
@@ -96,22 +95,6 @@ expect_allow() {
   fi
 }
 
-# Known gap: document a bypass that we accept as out-of-scope
-known_gap() {
-  local label="$1"
-  TOTAL=$((TOTAL + 1))
-  local decision
-  decision=$(get_decision)
-  if [[ -z "$decision" ]]; then
-    PASS=$((PASS + 1))
-    printf "  ${YELLOW}SKIP${RESET} %s (known gap — bypasses as expected)\n" "$label"
-  else
-    # If it's actually caught, even better
-    PASS=$((PASS + 1))
-    printf "  ${GREEN}PASS${RESET} %s (caught despite being a known gap!)\n" "$label"
-  fi
-}
-
 set_config() {
   local config="$1"
   mkdir -p "$TEST_DIR/.claude"
@@ -180,20 +163,20 @@ expect_blocked "git status && git push --force"
 teardown
 
 # ============================================================
-printf "\n${BOLD}3. Shell indirection (known gaps)${RESET}\n"
+printf "\n${BOLD}3. Shell indirection${RESET}\n"
 setup
 
 run_hook "$(bash_input 'eval "git push --force origin main"')"
-known_gap "eval with git push --force"
+expect_blocked "eval with git push --force"
 
 run_hook "$(bash_input 'cmd=push; git $cmd --force')"
-known_gap "variable expansion: git \$cmd --force"
+expect_blocked "variable expansion: git \$cmd --force"
 
 run_hook "$(bash_input '$(echo git) push --force')"
-known_gap "subshell: \$(echo git) push --force"
+expect_blocked "subshell: \$(echo git) push --force"
 
 run_hook "$(bash_input 'echo "push --force" | xargs git')"
-known_gap "xargs: echo | xargs git"
+expect_blocked "xargs: echo | xargs git"
 
 teardown
 
@@ -202,10 +185,10 @@ printf "\n${BOLD}4. Binary path instead of bare git${RESET}\n"
 setup
 
 run_hook "$(bash_input '/usr/bin/git push --force origin main')"
-known_gap "/usr/bin/git push --force"
+expect_blocked "/usr/bin/git push --force"
 
 run_hook "$(bash_input '/usr/bin/git commit --amend')"
-known_gap "/usr/bin/git commit --amend"
+expect_blocked "/usr/bin/git commit --amend"
 
 teardown
 
@@ -214,13 +197,13 @@ printf "\n${BOLD}5. Command wrappers${RESET}\n"
 setup
 
 run_hook "$(bash_input 'env git push --force origin main')"
-known_gap "env git push --force"
+expect_blocked "env git push --force"
 
 run_hook "$(bash_input 'command git push --force origin main')"
-known_gap "command git push --force"
+expect_blocked "command git push --force"
 
 run_hook "$(bash_input 'nice git push --force origin main')"
-known_gap "nice git push --force"
+expect_blocked "nice git push --force"
 
 teardown
 
@@ -228,13 +211,13 @@ teardown
 printf "\n${BOLD}6. Sanitizer edge cases${RESET}\n"
 setup
 
-# Backtick expansion (not stripped by the sanitizer)
+# Backtick expansion
 run_hook "$(bash_input 'git push `echo --force` origin main')"
-known_gap "backtick expansion: git push \`echo --force\`"
+expect_blocked "backtick expansion: git push \`echo --force\`"
 
 # $() expansion inside the command
 run_hook "$(bash_input 'git push $(echo --force) origin main')"
-known_gap "subshell expansion: git push \$(echo --force)"
+expect_blocked "subshell expansion: git push \$(echo --force)"
 
 # Unbalanced quotes — the sed should still strip what it can
 run_hook "$(bash_input "git commit --amend -m \"it's a fix\"")"
@@ -285,7 +268,7 @@ run_hook "$(bash_input 'git	commit	--amend')"
 expect_blocked "tab chars: git<tab>commit<tab>--amend"
 
 run_hook "$(bash_input $'git push \\\n--force origin main')"
-known_gap "line continuation: git push \\\\n--force"
+expect_blocked "line continuation: git push \\\\n--force"
 
 teardown
 


### PR DESCRIPTION
## Summary

Close all 5 known evasion gaps identified in the adversarial test suite (closes #35, closes #36).

## Gaps closed

| Gap | Evasion technique | Fix |
|-----|-------------------|-----|
| Shell eval | `eval "git push --force"` | Skip quote-stripping when `eval` detected |
| Variable subcommand | `git $cmd --force` | Deny `git $variable` in subcommand position |
| Subshell invocation | `$(echo git) push --force` | Unwrap `$()` and backtick syntax before scanning |
| xargs piping | `echo "push" \| xargs git` | Deny `xargs ... git` pattern |
| Line continuation | `git push \<nl>--force` | Collapse `\<newline>` before scanning |

## Test plan
- [x] 5 adversarial tests converted from `known_gap` to `expect_blocked`
- [x] All 59 adversarial tests pass
- [x] All 50 governance tests pass (no regressions)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)